### PR TITLE
Start/Stop docker network.

### DIFF
--- a/.github/workflows/build-ecs.yml
+++ b/.github/workflows/build-ecs.yml
@@ -80,16 +80,25 @@ jobs:
         with:
           path: project
 
+      - name: Start Docker Network
+        run: docker network create ${{ steps.env.outputs.project-name }}
+
       - name: Run build.sh
         working-directory: project
         run: ./build.sh
         env:
+          DOCKER_NETWORK: ${{ steps.env.outputs.project-name }}
           DOCKER_ARGS: |
             --builder ${{ steps.buildx.outputs.name }}
             --cache-from type=local,src=/tmp/.buildx-cache
             --cache-to type=local,dest=/tmp/.buildx-cache-new
             --tag ${{ steps.ecr.outputs.registry }}/${{ steps.env.outputs.project-name }}:${{ steps.env.outputs.environment}}-${{ steps.build-number.outputs.build-number}}
             --push
+
+      - name: Stop Docker Network
+        run: docker network rm ${{ steps.env.outputs.project-name }}
+        if: ${{ always() }}
+        continue-on-error: true
 
       # Temp fix
       # https://github.com/docker/build-push-action/issues/252


### PR DESCRIPTION
Some docker builds require a network before building. buildx requires the network to be set on creation of the builder. This means that all the app nows require a network. It doesn't hurt anything.