### PR TITLE
AEM Build : Core GHA

### DIFF
--- a/.github/workflows/aem-cloud-build.yml
+++ b/.github/workflows/aem-cloud-build.yml
@@ -1,0 +1,32 @@
+name: Java CI with Maven Build AEM repository
+
+on:
+  workflow_call:
+    secrets:
+      aem-cloud-artifactory-user:
+        description: AEM Cloud Artifactory User 
+        required: true
+      aem-cloud-artifactory-api-key:
+        description: AEM Cloud Artifactory API key
+        required: true
+
+jobs:
+  # Running jobs directly on the runner machine
+  aem:
+    runs-on: ubuntu-latest
+
+    # Service containers to run with `runner-job`
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: 'adopt'
+          overwrite-settings: false
+          cache: 'maven'
+      - name: Build project
+        env:
+          AEM_CLOUD_ARTIFACTORY_USER: ${{ secrets.aem-cloud-artifactory-user }}
+          AEM_CLOUD_ARTIFACTORY_API_KEY: ${{ secrets.aem-cloud-artifactory-api-key }}
+        run: mvn -e -s $GITHUB_WORKSPACE/.m2/settings.xml clean package


### PR DESCRIPTION
Intended to be used in building the a number of CruGlobal AEM repositories.

See for instance https://github.com/CruGlobal/aem-jersey-bundle/pull/7