### PR TITLE
Add Release Updater to update `v1` release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    name: Update Release Tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: sersoft-gmbh/running-release-tags-action@v2
+        with:
+          tag: v1
+          update-minor: false
+          create-release: false


### PR DESCRIPTION
I've been doing this manually whenever a new commit is added to `main`, This should do it automatically.