### PR TITLE
Use --build-service-account

### DIFF
--- a/.github/workflows/build-deploy-cloudrun-job.yml
+++ b/.github/workflows/build-deploy-cloudrun-job.yml
@@ -85,7 +85,7 @@ jobs:
           gcloud run jobs deploy ${{ inputs.job_name }} \
             --region=${{ vars.GCP_REGION }} \
             --image=us-central1-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/gcrj-artifacts/${{ inputs.job_name }}:latest \
-            --service-account=${{ vars.GCP_SERVICE_ACCOUNT_EMAIL }}
+            --build-service-account=projects/${{ vars.GCP_PROJECT_ID }}/serviceAccounts/${{ vars.GCP_SERVICE_ACCOUNT_EMAIL }}
 
       - uses: actions/github-script@v6
         if: github.event.pull_request.merged == true


### PR DESCRIPTION
The workflow updated the job definition SA to the build SA account during the deployment step. This corrects it, but using the correct flag. 