### PR TITLE
remove unrecognized arguments: --build-service-account

### DIFF
--- a/.github/workflows/build-deploy-cloudrun-job.yml
+++ b/.github/workflows/build-deploy-cloudrun-job.yml
@@ -84,8 +84,7 @@ jobs:
           gcloud config set project ${{ vars.GCP_PROJECT_ID }}
           gcloud run jobs deploy ${{ inputs.job_name }} \
             --region=${{ vars.GCP_REGION }} \
-            --image=us-central1-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/gcrj-artifacts/${{ inputs.job_name }}:latest \
-            --build-service-account=projects/${{ vars.GCP_PROJECT_ID }}/serviceAccounts/${{ vars.GCP_SERVICE_ACCOUNT_EMAIL }}
+            --image=us-central1-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/gcrj-artifacts/${{ inputs.job_name }}:latest 
 
       - uses: actions/github-script@v6
         if: github.event.pull_request.merged == true


### PR DESCRIPTION
For some reason I started getting this error: 
```
Run gcloud config set project cru-data-orchestration-prod
WARNING: Property [project] is overridden by environment setting [CLOUDSDK_CORE_PROJECT=cru-data-orchestration-prod]
Updated property [core/project].
ERROR: (gcloud.run.jobs.deploy) unrecognized arguments: --build-service-account=projects/cru-data-orchestration-prod/serviceAccounts/dot-github-sa@cru-data-orchestration-prod.iam.gserviceaccount.com (did you mean '--service-account'?) 

To search the help text of gcloud commands, run:
  gcloud help -- SEARCH_TERMS
Error: Process completed with exit code 2.

```