### PR TITLE
fix(deploy-cloudrun): preserve sidecar containers on deploy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cruglobal-dot-github",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cruglobal-dot-github",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cruglobal-dot-github",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Cru Actions and Workflows",
   "private": true,
   "sideEffects": false,

--- a/src/deploy-cloudrun.js
+++ b/src/deploy-cloudrun.js
@@ -63,14 +63,29 @@ async function updateCloudRun(projectName, project, environment, buildNumber) {
         await updateJobImage(job, imageUri, secrets)
     }
 
-    // Update each CloudRun service
+    // Update each CloudRun service. Refresh only the APP container's image/env
+    // and pass ALL containers through, so any sidecars are preserved — e.g. the
+    // Datadog Agent the gcp/cloudrun/app module adds when datadog_apm = true.
+    // (Previously this collapsed the service to containers[0], which dropped the
+    // sidecar — and broke the deploy outright when the app declared depends_on
+    // the agent.) The app container is the one running this project's image, or
+    // the ingress container (the one with a port) before the first real build;
+    // single-container services have exactly one and behave as before.
     // TODO: selectively update services?
+    const repo = imageUri.split(':')[0]
     for (const service of services) {
-        const container = service.template.containers[0]
-        container.image = imageUri
-        container.env = mergeEnvVars(container.env, secrets)
-        core.info(`updating service: ${service.name}`)
-        await updateService(service.name, container)
+        const containers = service.template.containers
+        const updated = containers.map(container => {
+            const isApp =
+                containers.length === 1 ||
+                container.image?.split(':')[0] === repo ||
+                (container.ports?.length ?? 0) > 0
+            return isApp
+                ? {...container, image: imageUri, env: mergeEnvVars(container.env, secrets)}
+                : container
+        })
+        core.info(`updating service: ${service.name} (${updated.length} container(s))`)
+        await updateService(service.name, updated)
     }
 }
 

--- a/src/gcp.js
+++ b/src/gcp.js
@@ -67,13 +67,16 @@ export async function runJob(name) {
     return execution
 }
 
-export async function updateService(name, template) {
+// `containers` is the full container list for the service template (the app
+// container plus any sidecars), so deploys preserve sidecars instead of
+// collapsing the service to a single container.
+export async function updateService(name, containers) {
     const client = new ServicesClient()
     const [operation] = await client.updateService({
         service: {
             name: name,
             template: {
-                containers: [template],
+                containers: containers,
                 annotations: {
                     "client.knative.dev/force-revision": Date.now().toString(),
                 }


### PR DESCRIPTION
## Problem
`actions/deploy-cloudrun` updated each service by grabbing **`template.containers[0]`**, setting its image/env, and calling `updateService` with just that one container — which sends `template.containers: [one]` with `updateMask: ["template.containers"]`, **replacing the entire container list**. So any **sidecar is dropped on every deploy**, and when the app declares `depends_on` the sidecar, the carried-over `depends_on` references a missing container → Cloud Run rejects the update → **the deploy fails**.

This blocks the Datadog Agent sidecar that `gcp/cloudrun/app` adds when `datadog_apm = true` (cru-terraform-modules#667).

## Fix
Update **only the app container's** image/env and pass the **full container list** through, so sidecars survive:
- App container = the one running this project's image (the `imageUri` repo) or, before the first build, the **ingress container** (the one with a port).
- **Single-container services are unchanged** — fully backward-compatible.
- `updateService` now takes the full `containers` array.

## Verification
`npm run lint`, `npm run build` (9 actions), and `npm test` (29 passing) pass. `dist/` not committed — `build-dist.yml` rebuilds it on merge.

## Release
Bumped `package.json` (+ lockfile) to **1.7.1**. On merge, `build-dist.yml` rebuilds `dist/` and moves the rolling **`v1`** tag (and `v1.7.1`) to the new commit, so `@v1` consumers (bills, etc.) pick up the fix. (The `Check Release Label` workflow is a vendored import from another team — not part of this repo's release path — so no `patch` label is needed.)

## Rollout note
Needs to be **merged** (→ `v1` moves) before a bills **stage** deploy runs with the sidecar (cru-terraform#11096), or that deploy drops/fails on the agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)