### PR TITLE
ci: adopt Release Please for versioning, tags, and releases

### DIFF
--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -1,24 +1,18 @@
-name: Build dist/ & Release
+name: Build dist/
 
-# Post-merge pipeline for main, run as a single ordered job:
-#   1. Rebuild the bundled dist/ artifacts and commit them back, so that
-#      contributors and Dependabot never have to run `npm run build`.
-#   2. Move the running release tag — but only AFTER dist/ has been rebuilt,
-#      so the tag always points at a fully-built commit.
+# Rebuild the bundled dist/ artifacts on every push to main and commit them
+# back, so contributors and Dependabot never have to run `npm run build` and
+# every commit on main is runnable as an action. Because dist/ is always
+# current on main, the commit release-please tags already carries the built
+# output. Versioning, tags and releases are handled by release-please.yml.
 #
-# This replaces the old standalone Release workflow, which fired on every
-# push to main and therefore ran twice per merge: once on the merge commit
-# (stale dist) and again on the dist-rebuild commit.
+# Triggers on every push to main EXCEPT commits that only touch dist/ — that is
+# the bot's own "build: rebuild dist/" commit. paths-ignore keeps it from
+# re-triggering this workflow, so the pipeline never loops.
 #
-# Triggers on every push to main EXCEPT commits that only touch dist/ — that
-# is the bot's own "build: rebuild dist/" commit. paths-ignore keeps it from
-# re-triggering this workflow, so the pipeline never loops and Release runs
-# exactly once per merge. Merges that don't change sources still run (dist is
-# rebuilt as a no-op) so the release tag is always updated.
-#
-# dist/ commits and tags are pushed with secrets.CRU_DEVOPS_GITHUB_TOKEN, a
-# PAT whose user can bypass the main branch ruleset; the default GITHUB_TOKEN
-# would be rejected.
+# dist/ commits are pushed with secrets.CRU_DEVOPS_GITHUB_TOKEN, a PAT whose
+# user can bypass the main branch ruleset; the default GITHUB_TOKEN would be
+# rejected.
 
 on:
   push:
@@ -30,20 +24,20 @@ on:
 permissions:
   contents: write
 
-# Avoid racing commits/tags if several merges land in quick succession.
+# Avoid racing commits if several merges land in quick succession.
 concurrency:
   group: build-dist
   cancel-in-progress: false
 
 jobs:
   build-dist:
-    name: Rebuild dist/ and release
+    name: Rebuild dist/
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
           # PAT for a user allowed to bypass the main branch ruleset, so the
-          # rebuilt dist/ and the release tags can be pushed straight to main.
+          # rebuilt dist/ can be pushed straight to main.
           token: ${{ secrets.CRU_DEVOPS_GITHUB_TOKEN }}
 
       - name: Set up Node.js
@@ -64,19 +58,3 @@ jobs:
           add: dist/
           message: 'build: rebuild dist/'
           default_author: github_actions
-
-      # Derive the release tag from package.json so the rolling major tag
-      # tracks the version automatically. Only the major is parsed from this
-      # (update-minor: false), so v1.7.0 keeps v1 pointed at the latest commit
-      # and a future 2.0.0 bump would correctly start moving v2.
-      - name: Read version from package.json
-        id: pkg
-        run: echo "tag=v$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
-
-      # Runs only after dist/ is rebuilt and committed above.
-      - name: Update running release tag
-        uses: sersoft-gmbh/running-release-tags-action@v4
-        with:
-          tag: ${{ steps.pkg.outputs.tag }}
-          update-minor: false
-          create-release: false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,75 @@
+name: Release Please
+
+# Release pipeline for this repo's actions/workflows.
+#
+# release-please reads Conventional Commits on main and maintains a release PR
+# (version bump in package.json + CHANGELOG.md). Merging that PR tags vX.Y.Z and
+# cuts a GitHub release; the roll-tags job then points the major (v1) and minor
+# (v1.7) tags at the same commit so consumers pinned to `@v1` / `@v1.7` track it.
+#
+# dist/ is kept current by build-dist.yml (rebuilt + committed on every push to
+# main), so the released commit already carries the built dist/ and the tags
+# never point at an unbuilt commit.
+#
+# CRU_DEVOPS_GITHUB_TOKEN (a PAT whose user bypasses the main branch ruleset) is
+# required so the release PR's commits trigger CI — the required "Lint, Build &
+# Test" check — which the default GITHUB_TOKEN cannot do, and so tag pushes are
+# allowed.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: release-please
+  cancel-in-progress: false
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+      major: ${{ steps.release.outputs.major }}
+      minor: ${{ steps.release.outputs.minor }}
+      sha: ${{ steps.release.outputs.sha }}
+    steps:
+      - uses: googleapis/release-please-action@v4
+        id: release
+        with:
+          release-type: node
+          token: ${{ secrets.CRU_DEVOPS_GITHUB_TOKEN }}
+
+  # Roll the major (v1) and minor (v1.7) tags onto the released commit so
+  # consumers pinned to `@v1` / `@v1.7` pick up the release. release-please
+  # already created the exact vX.Y.Z tag. Tags are moved via the refs API, so
+  # there's no checkout — and none of the shallow-clone tag-push pitfalls that
+  # silently broke the previous running-release-tags-action step.
+  roll-tags:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Roll v{major} and v{major}.{minor} to the release commit
+        env:
+          GH_TOKEN: ${{ secrets.CRU_DEVOPS_GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ needs.release-please.outputs.sha }}
+          MAJOR: ${{ needs.release-please.outputs.major }}
+          MINOR: ${{ needs.release-please.outputs.minor }}
+        run: |
+          roll() {
+            local tag="$1"
+            if gh api "repos/$REPO/git/refs/tags/$tag" >/dev/null 2>&1; then
+              gh api -X PATCH "repos/$REPO/git/refs/tags/$tag" -f sha="$SHA" -F force=true
+            else
+              gh api -X POST "repos/$REPO/git/refs" -f ref="refs/tags/$tag" -f sha="$SHA"
+            fi
+            echo "rolled $tag -> $SHA"
+          }
+          roll "v$MAJOR"
+          roll "v$MAJOR.$MINOR"


### PR DESCRIPTION
## Why
The release mechanism here was fragile and silently broken:
- Versions were bumped **by hand** in `package.json`.
- `build-dist.yml` moved the rolling `v1` tag via `sersoft-gmbh/running-release-tags-action` from a **shallow checkout**, which failed every release. As a result the only tags in the repo were `v1.0.0` and `v1`, and **`v1` had drifted 9 commits stale** — `@v1` consumers (bills' deploy, etc.) were running an old action bundle.

## What
Switch to **Release Please**, the same flow the bills app uses.

**`release-please.yml`** (new)
- `release-please` reads Conventional Commits on `main` and maintains a release PR (version bump in `package.json` + `CHANGELOG.md`). Merging it tags `vX.Y.Z` and cuts a GitHub release.
- A **`roll-tags`** job then points `v{major}` (`v1`) and `v{major}.{minor}` (`v1.7`) at the released commit via the refs API — **no checkout**, so none of the shallow-clone tag-push pitfalls that broke the old step.
- Uses `CRU_DEVOPS_GITHUB_TOKEN` so the release PR triggers the required **Lint, Build & Test** check (a default-`GITHUB_TOKEN` PR wouldn't) and tag pushes are allowed.

**`build-dist.yml`** (trimmed)
- Now does **only** what its name says: rebuild + commit `dist/` on every push to `main`. Since `dist/` is always current on `main`, the commit release-please tags already carries built output — the tags never point at an unbuilt commit. Versioning/tags moved to `release-please.yml`.

## Notes
- The `workflow_call` `check-pr-release-label` / `get-pr-release-label` workflows are **left untouched** — they're consumed by other apps' deployments, not this repo's release path.
- **Bootstrap is clean:** `package.json` is `1.7.1` and a `v1.7.1` tag now exists, so release-please starts from `v1.7.1`; the next `feat:`/`fix:` opens the first release PR. No giant historical CHANGELOG.
- `release-type: node`.

## Follow-up (optional)
`dist/` is kept current via the per-push rebuild (simplest, keeps `@main` runnable). If you'd rather cut the per-merge "build: rebuild dist/" churn, we can instead rebuild `dist/` only on the release PR — more moving parts, happy to do it if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)