### PR TITLE
feat(deploy-cloudrun): enable Datadog deploy tagging

### DIFF
--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -54,8 +54,8 @@ jobs:
           project-name: ${{ inputs.project-name }}
           environment: ${{ inputs.environment }}
 
-#      - name: Add DataDog Tags
-#        run: npx @datadog/datadog-ci tag --level pipeline --tags "service:$PROJECT_NAME" --tags "environment:$ENVIRONMENT" --tags "build_number:$BUILD_NUMBER"
+      - name: Add DataDog Tags
+        run: npx @datadog/datadog-ci tag --level pipeline --tags "service:$PROJECT_NAME" --tags "environment:$ENVIRONMENT" --tags "build_number:$BUILD_NUMBER"
 
       - name: Configure GCP credentials
         uses: google-github-actions/auth@v3


### PR DESCRIPTION
## Summary

Uncomments the **Add DataDog Tags** step in `deploy-cloudrun.yml` so CloudRun deploys tag the CI pipeline with `service`, `environment`, and `build_number` — bringing CloudRun to parity with `deploy-ecs.yml` and `deploy-lambda.yml`, which have run this step all along.

The step has been commented out since CloudRun support was added in #369; all the supporting plumbing already exists:
- `DD_API_KEY` is already set at the job level from the `datadog-api-key` secret (required by the `workflow_call` contract)
- cru-deploy's `deploy-cloudrun.yml` already passes `DD_API_KEY` to this workflow

With this enabled, CloudRun deployments become visible in Datadog CI Visibility alongside ECS and Lambda deploys — a prerequisite for any deployment-aware monitoring we build on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)