### PR TITLE
feat(deploy): mark deployments in Datadog CD Visibility

### DIFF
--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -75,4 +75,7 @@ jobs:
       - name: Update CloudRun
         uses: ./cru-github-actions/actions/deploy-cloudrun
 
+      - name: Mark Deployment in Datadog
+        run: npx @datadog/datadog-ci deployment mark --env "$ENVIRONMENT" --service "$PROJECT_NAME" --revision "$ENVIRONMENT-$BUILD_NUMBER" --tags "build_number:$BUILD_NUMBER"
+
       - run: echo "::notice title=Deploy Success::Successfully deployed - $PROJECT_NAME ($ENVIRONMENT-$BUILD_NUMBER)"

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -65,4 +65,7 @@ jobs:
       - name: Update and register Task Definition
         uses: ./cru-github-actions/actions/deploy-ecs
 
+      - name: Mark Deployment in Datadog
+        run: npx @datadog/datadog-ci deployment mark --env "$ENVIRONMENT" --service "$PROJECT_NAME" --revision "$ENVIRONMENT-$BUILD_NUMBER" --tags "build_number:$BUILD_NUMBER"
+
       - run: echo "::notice title=Deploy Success::Successfully deployed - $PROJECT_NAME ($ENVIRONMENT-$BUILD_NUMBER)"

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -65,4 +65,7 @@ jobs:
       - name: Deploy Lambda Functions
         uses: ./cru-github-actions/actions/deploy-lambda
 
+      - name: Mark Deployment in Datadog
+        run: npx @datadog/datadog-ci deployment mark --env "$ENVIRONMENT" --service "$PROJECT_NAME" --revision "$ENVIRONMENT-$BUILD_NUMBER" --tags "build_number:$BUILD_NUMBER"
+
       - run: echo "::notice title=Deploy Success::Successfully deployed - $PROJECT_NAME ($ENVIRONMENT-$BUILD_NUMBER)"


### PR DESCRIPTION
## Summary

Adds a **Mark Deployment in Datadog** step (`datadog-ci deployment mark`) to all three deploy workflows — `deploy-ecs.yml`, `deploy-lambda.yml`, `deploy-cloudrun.yml` — recording every successful deploy as a deployment event with `env`, `service`, and `revision` (`<environment>-<build-number>`, the image tag).

## Why

- Deploys become first-class events in Datadog **CD Visibility** (Deployments view, DORA metrics: deployment frequency, change failure rate, MTTR), not just pipeline tags.
- This is the telemetry foundation the agentic-lifecycle RFC's safety nets assume: severity-gated auto-rollback and the self-healing loop both need to correlate error signal against *which release just shipped*. Deployment marking gives Datadog that per-release anchor.
- `--is-rollback` is available on the same command for the future rollback path.

## Notes

- Originally stacked on #421, which has merged — this PR now targets `main` directly.
- The step runs after the deploy action succeeds, so failed deploys are never marked.
- `DD_API_KEY` is already present at the job level in all three workflows; no new secrets.
- Requires Datadog's GitHub Actions CI Visibility integration to be collecting this repo/cru-deploy's pipelines (already true for the existing `datadog-ci tag` step on ECS/Lambda).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
