### PR TITLE
fix(release-please): exact-match tag rolling + bootstrap to 1.8.0

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -64,7 +64,10 @@ jobs:
         run: |
           roll() {
             local tag="$1"
-            if gh api "repos/$REPO/git/refs/tags/$tag" >/dev/null 2>&1; then
+            # GET /git/refs/tags/<tag> prefix-matches (v1.1 "exists" because
+            # v1.1.0 does), so require an exact ref via matching-refs before
+            # choosing update-vs-create.
+            if gh api "repos/$REPO/git/matching-refs/tags/$tag" --jq '.[].ref' | grep -qx "refs/tags/$tag"; then
               gh api -X PATCH "repos/$REPO/git/refs/tags/$tag" -f sha="$SHA" -F force=true
             else
               gh api -X POST "repos/$REPO/git/refs" -f ref="refs/tags/$tag" -f sha="$SHA"


### PR DESCRIPTION
## Summary

Two things, one release:

**1. Fixes the failed `roll-tags` job** from the v1.1.0 release. The existence check used `GET /git/refs/tags/<tag>`, which does *prefix matching* — `v1.1` appeared to exist because `v1.1.0` does — so the job took the PATCH path against a nonexistent `v1.1` ref and got HTTP 422. (`v1` rolled fine because it exists exactly.) The check now requires an exact ref via `matching-refs` before choosing update-vs-create.

**2. Bootstraps release-please past the legacy tag series** via the `Release-As: 1.8.0` commit footer. Release-please restarted versioning at v1.0.0/v1.1.0, but tags from the pre-release-please era exist up through `v1.7.1` — the new series would eventually collide with them. Jumping to 1.8.0 puts us cleanly past the old series.

## What happens after merge

1. release-please opens a release PR for **1.8.0** (package.json 1.1.0 → 1.8.0 + changelog).
2. Merging that PR tags `v1.8.0`, and the fixed `roll-tags` job creates `v1.8` (exact-match miss → create) and force-rolls `v1`.

Note: `v1.1` was never created due to the bug; not worth backfilling since nothing pins to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)