### PR TITLE
fix(deploy): replace removed 'deployment mark' with dora deployment; telemetry can't fail deploys

### DIFF
--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -54,8 +54,14 @@ jobs:
           project-name: ${{ inputs.project-name }}
           environment: ${{ inputs.environment }}
 
+      - name: Record deploy start
+        run: echo "DEPLOY_STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
+
+      # Telemetry must never fail a deploy: pinned CLI major, --no-fail, and
+      # continue-on-error guard against upstream CLI changes and Datadog outages.
       - name: Add DataDog Tags
-        run: npx @datadog/datadog-ci tag --level pipeline --tags "service:$PROJECT_NAME" --tags "environment:$ENVIRONMENT" --tags "build_number:$BUILD_NUMBER"
+        continue-on-error: true
+        run: npx @datadog/datadog-ci@5 tag --level pipeline --no-fail --tags "service:$PROJECT_NAME" --tags "environment:$ENVIRONMENT" --tags "build_number:$BUILD_NUMBER"
 
       - name: Configure GCP credentials
         uses: google-github-actions/auth@v3
@@ -75,7 +81,16 @@ jobs:
       - name: Update CloudRun
         uses: ./cru-github-actions/actions/deploy-cloudrun
 
-      - name: Mark Deployment in Datadog
-        run: npx @datadog/datadog-ci deployment mark --env "$ENVIRONMENT" --service "$PROJECT_NAME" --revision "$ENVIRONMENT-$BUILD_NUMBER" --tags "build_number:$BUILD_NUMBER"
+      - name: Record Deployment in Datadog
+        continue-on-error: true
+        run: >-
+          npx @datadog/datadog-ci@5 dora deployment
+          --service "$PROJECT_NAME"
+          --env "$ENVIRONMENT"
+          --version "$ENVIRONMENT-$BUILD_NUMBER"
+          --started-at "$DEPLOY_STARTED_AT"
+          --finished-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          --skip-git
+          --custom-tags "build_number:$BUILD_NUMBER"
 
       - run: echo "::notice title=Deploy Success::Successfully deployed - $PROJECT_NAME ($ENVIRONMENT-$BUILD_NUMBER)"

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -50,8 +50,14 @@ jobs:
           project-name: ${{ inputs.project-name }}
           environment: ${{ inputs.environment }}
 
+      - name: Record deploy start
+        run: echo "DEPLOY_STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
+
+      # Telemetry must never fail a deploy: pinned CLI major, --no-fail, and
+      # continue-on-error guard against upstream CLI changes and Datadog outages.
       - name: Add DataDog Tags
-        run: npx @datadog/datadog-ci tag --level pipeline --tags "service:$PROJECT_NAME" --tags "environment:$ENVIRONMENT" --tags "build_number:$BUILD_NUMBER"
+        continue-on-error: true
+        run: npx @datadog/datadog-ci@5 tag --level pipeline --no-fail --tags "service:$PROJECT_NAME" --tags "environment:$ENVIRONMENT" --tags "build_number:$BUILD_NUMBER"
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
@@ -65,7 +71,16 @@ jobs:
       - name: Update and register Task Definition
         uses: ./cru-github-actions/actions/deploy-ecs
 
-      - name: Mark Deployment in Datadog
-        run: npx @datadog/datadog-ci deployment mark --env "$ENVIRONMENT" --service "$PROJECT_NAME" --revision "$ENVIRONMENT-$BUILD_NUMBER" --tags "build_number:$BUILD_NUMBER"
+      - name: Record Deployment in Datadog
+        continue-on-error: true
+        run: >-
+          npx @datadog/datadog-ci@5 dora deployment
+          --service "$PROJECT_NAME"
+          --env "$ENVIRONMENT"
+          --version "$ENVIRONMENT-$BUILD_NUMBER"
+          --started-at "$DEPLOY_STARTED_AT"
+          --finished-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          --skip-git
+          --custom-tags "build_number:$BUILD_NUMBER"
 
       - run: echo "::notice title=Deploy Success::Successfully deployed - $PROJECT_NAME ($ENVIRONMENT-$BUILD_NUMBER)"

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -50,8 +50,14 @@ jobs:
           project-name: ${{ inputs.project-name }}
           environment: ${{ inputs.environment }}
 
+      - name: Record deploy start
+        run: echo "DEPLOY_STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
+
+      # Telemetry must never fail a deploy: pinned CLI major, --no-fail, and
+      # continue-on-error guard against upstream CLI changes and Datadog outages.
       - name: Add DataDog Tags
-        run: npx @datadog/datadog-ci tag --level pipeline --tags "service:$PROJECT_NAME" --tags "environment:$ENVIRONMENT" --tags "build_number:$BUILD_NUMBER"
+        continue-on-error: true
+        run: npx @datadog/datadog-ci@5 tag --level pipeline --no-fail --tags "service:$PROJECT_NAME" --tags "environment:$ENVIRONMENT" --tags "build_number:$BUILD_NUMBER"
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
@@ -65,7 +71,16 @@ jobs:
       - name: Deploy Lambda Functions
         uses: ./cru-github-actions/actions/deploy-lambda
 
-      - name: Mark Deployment in Datadog
-        run: npx @datadog/datadog-ci deployment mark --env "$ENVIRONMENT" --service "$PROJECT_NAME" --revision "$ENVIRONMENT-$BUILD_NUMBER" --tags "build_number:$BUILD_NUMBER"
+      - name: Record Deployment in Datadog
+        continue-on-error: true
+        run: >-
+          npx @datadog/datadog-ci@5 dora deployment
+          --service "$PROJECT_NAME"
+          --env "$ENVIRONMENT"
+          --version "$ENVIRONMENT-$BUILD_NUMBER"
+          --started-at "$DEPLOY_STARTED_AT"
+          --finished-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          --skip-git
+          --custom-tags "build_number:$BUILD_NUMBER"
 
       - run: echo "::notice title=Deploy Success::Successfully deployed - $PROJECT_NAME ($ENVIRONMENT-$BUILD_NUMBER)"


### PR DESCRIPTION
## Summary

Fixes the incident from #422's deployment marking: **datadog-ci v5 removed `deployment mark`** (superseded by `dora deployment`), and the unpinned `npx` invocation pulls latest — so every cru-deploy run failed on the post-deploy step. The deploys themselves all succeeded (the step runs after the runtime update); `v1` was emergency-repointed to `e16d3f5` as mitigation.

Three changes across `deploy-ecs.yml` / `deploy-lambda.yml` / `deploy-cloudrun.yml`:

1. **`dora deployment` replaces `deployment mark`** — same telemetry goal (deployment events, DORA metrics) via the supported v5 command: `--service`/`--env`/`--version`, `--started-at` captured in a new step before the deploy, `--finished-at` at completion, `--skip-git` (the job's checkout is this repo, not the app repo).
2. **Pinned CLI major** (`@datadog/datadog-ci@5`) on both Datadog steps — the root cause was an upstream breaking change landing unreviewed through an unpinned CLI in the deploy path.
3. **Telemetry can never fail a deploy again**: `continue-on-error: true` on both steps plus `--no-fail` on the tag command. A Datadog outage or CLI regression now shows an annotation, not a red deploy.

## Sequencing

Merge this **and** #424 before merging the next release-please release PR — the release (1.8.0 via #424's `Release-As`) is what rolls `v1` forward off the emergency pin onto fixed code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)