### PR TITLE
fix(deploy): post standard Datadog events instead of DORA product events

### DIFF
--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -81,16 +81,22 @@ jobs:
       - name: Update CloudRun
         uses: ./cru-github-actions/actions/deploy-cloudrun
 
-      - name: Record Deployment in Datadog
+      - name: Record deployment event in Datadog
         continue-on-error: true
-        run: >-
-          npx @datadog/datadog-ci@5 dora deployment
-          --service "$PROJECT_NAME"
-          --env "$ENVIRONMENT"
-          --version "$ENVIRONMENT-$BUILD_NUMBER"
-          --started-at "$DEPLOY_STARTED_AT"
-          --finished-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          --skip-git
-          --custom-tags "build_number:$BUILD_NUMBER"
+        run: |
+          jq -n \
+            --arg title "Deployed: $PROJECT_NAME $ENVIRONMENT-$BUILD_NUMBER" \
+            --arg text "v1 pipeline deploy (started $DEPLOY_STARTED_AT)" \
+            --arg service "$PROJECT_NAME" \
+            --arg env "$ENVIRONMENT" \
+            --arg rev "$ENVIRONMENT-$BUILD_NUMBER" \
+            --arg bn "$BUILD_NUMBER" \
+            '{title: $title, text: $text, alert_type: "info",
+              aggregation_key: ("deploy:" + $service + ":" + $env),
+              tags: ["source:cru-pipeline-v1", ("service:" + $service),
+                     ("environment:" + $env), "action:deploy",
+                     ("revision:" + $rev), ("build_number:" + $bn)]}' \
+          | curl -fsS --retry 3 -X POST "https://api.datadoghq.com/api/v1/events" \
+              -H "Content-Type: application/json" -H "DD-API-KEY: $DD_API_KEY" -d @-
 
       - run: echo "::notice title=Deploy Success::Successfully deployed - $PROJECT_NAME ($ENVIRONMENT-$BUILD_NUMBER)"

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -71,16 +71,22 @@ jobs:
       - name: Update and register Task Definition
         uses: ./cru-github-actions/actions/deploy-ecs
 
-      - name: Record Deployment in Datadog
+      - name: Record deployment event in Datadog
         continue-on-error: true
-        run: >-
-          npx @datadog/datadog-ci@5 dora deployment
-          --service "$PROJECT_NAME"
-          --env "$ENVIRONMENT"
-          --version "$ENVIRONMENT-$BUILD_NUMBER"
-          --started-at "$DEPLOY_STARTED_AT"
-          --finished-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          --skip-git
-          --custom-tags "build_number:$BUILD_NUMBER"
+        run: |
+          jq -n \
+            --arg title "Deployed: $PROJECT_NAME $ENVIRONMENT-$BUILD_NUMBER" \
+            --arg text "v1 pipeline deploy (started $DEPLOY_STARTED_AT)" \
+            --arg service "$PROJECT_NAME" \
+            --arg env "$ENVIRONMENT" \
+            --arg rev "$ENVIRONMENT-$BUILD_NUMBER" \
+            --arg bn "$BUILD_NUMBER" \
+            '{title: $title, text: $text, alert_type: "info",
+              aggregation_key: ("deploy:" + $service + ":" + $env),
+              tags: ["source:cru-pipeline-v1", ("service:" + $service),
+                     ("environment:" + $env), "action:deploy",
+                     ("revision:" + $rev), ("build_number:" + $bn)]}' \
+          | curl -fsS --retry 3 -X POST "https://api.datadoghq.com/api/v1/events" \
+              -H "Content-Type: application/json" -H "DD-API-KEY: $DD_API_KEY" -d @-
 
       - run: echo "::notice title=Deploy Success::Successfully deployed - $PROJECT_NAME ($ENVIRONMENT-$BUILD_NUMBER)"

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -71,16 +71,22 @@ jobs:
       - name: Deploy Lambda Functions
         uses: ./cru-github-actions/actions/deploy-lambda
 
-      - name: Record Deployment in Datadog
+      - name: Record deployment event in Datadog
         continue-on-error: true
-        run: >-
-          npx @datadog/datadog-ci@5 dora deployment
-          --service "$PROJECT_NAME"
-          --env "$ENVIRONMENT"
-          --version "$ENVIRONMENT-$BUILD_NUMBER"
-          --started-at "$DEPLOY_STARTED_AT"
-          --finished-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          --skip-git
-          --custom-tags "build_number:$BUILD_NUMBER"
+        run: |
+          jq -n \
+            --arg title "Deployed: $PROJECT_NAME $ENVIRONMENT-$BUILD_NUMBER" \
+            --arg text "v1 pipeline deploy (started $DEPLOY_STARTED_AT)" \
+            --arg service "$PROJECT_NAME" \
+            --arg env "$ENVIRONMENT" \
+            --arg rev "$ENVIRONMENT-$BUILD_NUMBER" \
+            --arg bn "$BUILD_NUMBER" \
+            '{title: $title, text: $text, alert_type: "info",
+              aggregation_key: ("deploy:" + $service + ":" + $env),
+              tags: ["source:cru-pipeline-v1", ("service:" + $service),
+                     ("environment:" + $env), "action:deploy",
+                     ("revision:" + $rev), ("build_number:" + $bn)]}' \
+          | curl -fsS --retry 3 -X POST "https://api.datadoghq.com/api/v1/events" \
+              -H "Content-Type: application/json" -H "DD-API-KEY: $DD_API_KEY" -d @-
 
       - run: echo "::notice title=Deploy Success::Successfully deployed - $PROJECT_NAME ($ENVIRONMENT-$BUILD_NUMBER)"


### PR DESCRIPTION
## Summary

Replaces the `datadog-ci dora deployment` step (from #422/#425) in all three v1 deploy workflows with a structured post to the **standard Datadog Events API** — included with the platform, no separate SKU.

## Why

DORA Metrics is a separate per-committer SKU with unclear per-app billing exposure. Our deliberate telemetry cost model is a single CI Visibility committer on cru-deploy giving fleet-wide deploy visibility — the DORA product would undermine that. (In practice the DORA events have been bouncing off per-service source settings anyway.) Deployment events now carry `source:cru-pipeline-v1`, `service`, `environment`, `action:deploy`, `revision`, `build_number` tags — usable in dashboards, monitors, and deploy-correlation overlays.

Same `continue-on-error` guard: telemetry still cannot fail a deploy. The pipeline-v2 branch got the equivalent change in `6cc5e60`; DORA-style metrics (frequency, lead time, rollback rate) move to a self-owned ledger via an app-info extension (deferred, documented in docs/pipeline-v2.md on that branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)