### PR TITLE
feat(aem-cloud-build): add java-version input, default 11

### DIFF
--- a/.github/workflows/aem-cloud-build.yml
+++ b/.github/workflows/aem-cloud-build.yml
@@ -2,6 +2,12 @@ name: Java CI with Maven Build AEM repository
 
 on:
   workflow_call:
+    inputs:
+      java-version:
+        description: JDK version used to build (11 or 21)
+        required: false
+        type: string
+        default: '11'
     secrets:
       aem-cloud-artifactory-user:
         description: AEM Cloud Artifactory User 
@@ -18,11 +24,13 @@ jobs:
     # Service containers to run with `runner-job`
     steps:
       - uses: actions/checkout@v7
-      - name: Set up JDK 11
+      - name: Set up JDK ${{ inputs.java-version }}
         uses: actions/setup-java@v5
         with:
-          java-version: 11
-          distribution: 'adopt'
+          java-version: ${{ inputs.java-version }}
+          # AdoptOpenJDK ended at JDK 16 and became Eclipse Temurin, so it can
+          # only serve the legacy 11 default. Anything else resolves to temurin.
+          distribution: ${{ inputs.java-version == '11' && 'adopt' || 'temurin' }}
           overwrite-settings: false
           cache: 'maven'
       - name: Build project


### PR DESCRIPTION
AEM builds are moving from Java 11 to 21, but the 8 repos calling this workflow can't all move at once. Make the build JDK selectable so each repo opts in on its own schedule by passing java-version: '21'.

Default stays '11', so callers that pass no `with:` block are unaffected.

Distribution is derived rather than exposed as a second input: AdoptOpenJDK ended at JDK 16 and became Eclipse Temurin, so 'adopt' can only serve the legacy 11 default and anything else must resolve to temurin. Deriving it keeps the existing 11 toolchain byte-identical and means opting into 21 needs no knowledge of which vendor supplies it.

Note this selects the JDK Maven runs on, not the bytecode emitted -- projects setting <release>11</release> keep producing Java 11 bytecode until they raise it themselves.