### PR TITLE
fix(v2): resolve running image from jobs for jobs-only cloudrun apps

### DIFF
--- a/src/v2/gcp.js
+++ b/src/v2/gcp.js
@@ -64,6 +64,17 @@ export function findAppContainer (containers, repo) {
   )
 }
 
+// Cloud Run's own "hello" placeholder image, e.g.
+// us-docker.pkg.dev/cloudrun/container/hello[:latest]. Terraform boots a NEW
+// service/job on it, so a container still running it has never been deployed
+// and carries no resolvable app image — the Cloud Run equivalent of ECS's and
+// Lambda's `scratch` placeholder.
+const CLOUDRUN_PLACEHOLDER_REPO = 'us-docker.pkg.dev/cloudrun/container/'
+
+export function isPlaceholderImage (image) {
+  return image != null && parseImageRef(image).name.startsWith(CLOUDRUN_PLACEHOLDER_REPO)
+}
+
 // gaxios retry options for the Artifact Registry REST calls. The AWS SDK clients
 // already retry (maxAttempts 5, standard mode); the GCP REST path did NOT, and a
 // transient Artifact Registry 503 failed a pilot rollback at the resolve step

--- a/src/v2/resolve-cloudrun.js
+++ b/src/v2/resolve-cloudrun.js
@@ -1,13 +1,23 @@
 import * as core from '@actions/core'
-import { cloudrunListServices } from '../gcp'
+import { cloudrunListJobs, cloudrunListServices } from '../gcp'
 import {
   findAppContainer,
   isDigestRef,
+  isPlaceholderImage,
   parseImageRef,
   resolveTag,
   sharedRegistryImage,
   tagsForDigest
 } from './gcp'
+
+// The database-migrations job (see src/v2/deploy-cloudrun.js) runs the app
+// image too, but it is refreshed *before* the rest of a deploy and executed;
+// it is never a witness of what is currently serving. Skip it when reading a
+// running image back out of an environment.
+const DB_MIGRATE_JOB = 'db-migrate'
+
+// A job's/service's `name` is a full resource path (projects/.../<kind>/<name>).
+const shortName = resource => resource.split('/').pop()
 
 // Resolve a Cloud Run image to a digest reference in the shared registry.
 //
@@ -41,15 +51,37 @@ async function resolveRunningImage (projectName, runtimeProject) {
   let runningImage
   for (const service of services) {
     const container = findAppContainer(service.template?.containers ?? [], repo)
-    if (container?.image) {
+    if (container?.image && !isPlaceholderImage(container.image)) {
       runningImage = container.image
       core.info(`app container image in ${service.name}: ${runningImage}`)
       break
     }
   }
 
+  // Jobs-only apps (no Cloud Run services at all) still carry the deployed app
+  // image on their jobs — deploy-cloudrun.js updates every job's image. Fall
+  // back to them so such an app can be resolved (and therefore promoted).
+  // Services stay first priority: for a service-ful app nothing changes.
   if (!runningImage) {
-    throw new Error(`Could not find a running app container image in project ${runtimeProject}`)
+    const jobs = await cloudrunListJobs(runtimeProject)
+    core.info(`jobs in ${runtimeProject}: ${JSON.stringify(jobs.map(j => j.name))}`)
+    for (const job of jobs) {
+      if (shortName(job.name) === DB_MIGRATE_JOB) continue
+      const container = findAppContainer(job.template?.template?.containers ?? [], repo)
+      if (container?.image && !isPlaceholderImage(container.image)) {
+        runningImage = container.image
+        core.info(`app container image in ${job.name}: ${runningImage}`)
+        break
+      }
+    }
+  }
+
+  if (!runningImage) {
+    throw new Error(
+      `Could not find a running app container image in project ${runtimeProject} ` +
+      '(checked Cloud Run services and jobs; any job still on the Cloud Run placeholder image ' +
+      'has never been deployed)'
+    )
   }
 
   if (isDigestRef(runningImage)) {

--- a/test/v2-gcp.test.js
+++ b/test/v2-gcp.test.js
@@ -17,6 +17,7 @@ import {
   findAppContainer,
   isAppContainer,
   isDigestRef,
+  isPlaceholderImage,
   isTagRef,
   listDockerImages,
   parseImageRef,
@@ -120,6 +121,20 @@ describe('app container heuristics', () => {
     const ingress = { image: 'placeholder:latest', ports: [{ containerPort: 3000 }] }
     const containers = [sidecar, ingress]
     expect(findAppContainer(containers, repo)).toBe(ingress)
+  })
+})
+
+describe('never-deployed placeholder image', () => {
+  it('recognises the Cloud Run hello image, tagged or bare', () => {
+    expect(isPlaceholderImage('us-docker.pkg.dev/cloudrun/container/hello')).toBe(true)
+    expect(isPlaceholderImage('us-docker.pkg.dev/cloudrun/container/hello:latest')).toBe(true)
+    expect(isPlaceholderImage('us-docker.pkg.dev/cloudrun/container/hello@sha256:aaa')).toBe(true)
+  })
+
+  it('does not flag real app images', () => {
+    expect(isPlaceholderImage(`${HOST}/cru-shared-artifacts/hoax/hoax@sha256:aaa`)).toBe(false)
+    expect(isPlaceholderImage('gcr.io/datadoghq/agent:latest')).toBe(false)
+    expect(isPlaceholderImage(null)).toBe(false)
   })
 })
 

--- a/test/v2-resolve.test.js
+++ b/test/v2-resolve.test.js
@@ -8,11 +8,13 @@ vi.mock('google-auth-library', () => ({
   }
 }))
 
-// v1 gcp module: only cloudrunListServices is exercised here. DEFAULT_REGION is
-// re-exported so src/v2/gcp.js's SHARED_LOCATION resolves under the mock.
+// v1 gcp module: only the Cloud Run list calls are exercised here.
+// DEFAULT_REGION is re-exported so src/v2/gcp.js's SHARED_LOCATION resolves
+// under the mock.
 vi.mock('../src/gcp.js', () => ({
   DEFAULT_REGION: 'us-central1',
-  cloudrunListServices: vi.fn()
+  cloudrunListServices: vi.fn(),
+  cloudrunListJobs: vi.fn()
 }))
 
 import * as gcp from '../src/gcp.js'
@@ -25,9 +27,21 @@ const IMAGES = [
   { uri: `${REPO}@sha256:bbb`, tags: ['candidate-10013', 'release-3'] }
 ]
 
+const PLACEHOLDER = 'us-docker.pkg.dev/cloudrun/container/hello'
+
+// A Cloud Run job resource: image lives at template.template.containers.
+function job (name, image) {
+  return {
+    name: `projects/p/locations/us-central1/jobs/${name}`,
+    template: { template: { containers: [{ image }] } }
+  }
+}
+
 beforeEach(() => {
   requestMock.mockReset()
   gcp.cloudrunListServices.mockReset()
+  gcp.cloudrunListJobs.mockReset()
+  gcp.cloudrunListJobs.mockResolvedValue([])
 })
 
 describe('resolveCloudRun mode=tag', () => {
@@ -125,11 +139,113 @@ describe('resolveCloudRun mode=environment', () => {
     ).rejects.toThrow(/runtime-project is required/)
   })
 
-  it('throws when no running app image is found', async () => {
+  it('throws when neither services nor jobs yield an app image', async () => {
     gcp.cloudrunListServices.mockResolvedValue([])
     await expect(
       resolveCloudRun({ mode: 'environment', projectName: 'hoax', environment: 'production', runtimeProject: 'p' })
+    ).rejects.toThrow(/Could not find a running app container image .*checked Cloud Run services and jobs/s)
+  })
+})
+
+describe('resolveCloudRun mode=environment jobs-only apps', () => {
+  it('falls back to a job when the app has no services', async () => {
+    gcp.cloudrunListServices.mockResolvedValue([])
+    gcp.cloudrunListJobs.mockResolvedValue([
+      job('db-migrate', `${REPO}@sha256:bbb`),
+      job('hoax-worker', `${REPO}@sha256:aaa`)
+    ])
+    requestMock.mockResolvedValue({ data: { dockerImages: IMAGES } })
+
+    const result = await resolveCloudRun({
+      mode: 'environment',
+      projectName: 'hoax',
+      environment: 'production',
+      runtimeProject: 'hoax-prod-1234'
+    })
+
+    // db-migrate is skipped, so the worker's digest wins.
+    expect(result).toEqual({
+      image: `${REPO}@sha256:aaa`,
+      digest: 'sha256:aaa',
+      tags: ['candidate-10012', 'sha-abc123']
+    })
+    expect(gcp.cloudrunListJobs).toHaveBeenCalledWith('hoax-prod-1234')
+  })
+
+  it('resolves a tag ref carried by a job', async () => {
+    gcp.cloudrunListServices.mockResolvedValue([])
+    gcp.cloudrunListJobs.mockResolvedValue([job('hoax-worker', `${REPO}:release-3`)])
+    requestMock.mockResolvedValue({ data: { dockerImages: IMAGES } })
+
+    const result = await resolveCloudRun({
+      mode: 'environment',
+      projectName: 'hoax',
+      environment: 'production',
+      runtimeProject: 'hoax-prod-1234'
+    })
+
+    expect(result).toEqual({
+      image: `${REPO}@sha256:bbb`,
+      digest: 'sha256:bbb',
+      tags: ['candidate-10013', 'release-3']
+    })
+  })
+
+  it('throws when db-migrate is the only job', async () => {
+    gcp.cloudrunListServices.mockResolvedValue([])
+    gcp.cloudrunListJobs.mockResolvedValue([job('db-migrate', `${REPO}@sha256:aaa`)])
+
+    await expect(
+      resolveCloudRun({ mode: 'environment', projectName: 'hoax', environment: 'production', runtimeProject: 'p' })
     ).rejects.toThrow(/Could not find a running app container/)
+    expect(requestMock).not.toHaveBeenCalled()
+  })
+
+  it('throws when the only job still runs the never-deployed placeholder image', async () => {
+    gcp.cloudrunListServices.mockResolvedValue([])
+    gcp.cloudrunListJobs.mockResolvedValue([job('hoax-worker', PLACEHOLDER)])
+
+    await expect(
+      resolveCloudRun({ mode: 'environment', projectName: 'hoax', environment: 'production', runtimeProject: 'p' })
+    ).rejects.toThrow(/Could not find a running app container/)
+  })
+
+  it('skips a placeholder job and keeps looking', async () => {
+    gcp.cloudrunListServices.mockResolvedValue([])
+    gcp.cloudrunListJobs.mockResolvedValue([
+      job('hoax-idle', `${PLACEHOLDER}:latest`),
+      job('hoax-worker', `${REPO}@sha256:aaa`)
+    ])
+    requestMock.mockResolvedValue({ data: { dockerImages: IMAGES } })
+
+    const result = await resolveCloudRun({
+      mode: 'environment',
+      projectName: 'hoax',
+      environment: 'production',
+      runtimeProject: 'p'
+    })
+
+    expect(result.digest).toBe('sha256:aaa')
+  })
+
+  it('never lists jobs when a service already yields the app image', async () => {
+    gcp.cloudrunListServices.mockResolvedValue([
+      {
+        name: 'projects/p/locations/us-central1/services/hoax-web',
+        template: { containers: [{ image: `${REPO}@sha256:aaa`, ports: [{ containerPort: 8080 }] }] }
+      }
+    ])
+    requestMock.mockResolvedValue({ data: { dockerImages: IMAGES } })
+
+    const result = await resolveCloudRun({
+      mode: 'environment',
+      projectName: 'hoax',
+      environment: 'production',
+      runtimeProject: 'p'
+    })
+
+    expect(result.digest).toBe('sha256:aaa')
+    expect(gcp.cloudrunListJobs).not.toHaveBeenCalled()
   })
 })
 


### PR DESCRIPTION
`resolve-image` (mode: environment) only looked at Cloud Run *Services*, so a jobs-only app (`gcp/cloudrun/app` with `services = []`) could never be promoted — promote.yml's "Resolve running release-candidate image" step threw. `deploy-cloudrun.js` already rolls every job's image, so jobs are a faithful witness of what's deployed.

- Falls back to jobs when no service yields an app-container image: skips `db-migrate` (refreshed+executed pre-deploy; not a witness of what's serving) and placeholder images.
- New `isPlaceholderImage()` in `src/v2/gcp.js` (`us-docker.pkg.dev/cloudrun/container/*`) — the Cloud Run analogue of ECS/Lambda's `scratch`. Services on the placeholder also now fall through instead of resolving.
- Services stay first priority; service-ful apps behave identically.
- Error message now says both services and jobs were checked.

Tests: jobs-only resolve, db-migrate-only error, placeholder handling, services-first priority; 314 passing, lint clean.

Pilot: pgtobq (jobs-only pipeline-v2 app; see the cru-terraform `pgtobq-app-module` PR).


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016UVkeSQaemWL1R5QMHB7kZ