### PR TITLE
fix(v2): build-candidate gets a ref guard, a lock and failure notifications

### DIFF
--- a/.github/workflows/build-candidate.yml
+++ b/.github/workflows/build-candidate.yml
@@ -46,6 +46,22 @@ jobs:
     outputs:
       project-name: ${{ steps.info.outputs.project-name }}
     steps:
+      # A candidate is promotable by definition: whatever this run builds can be
+      # deployed to release-candidate and promoted to production, and nothing
+      # downstream re-checks where it came from. So the ref is asserted here,
+      # before a build number is burned or an image is pushed. `schedule` can
+      # only ever run on the default branch; this covers workflow_dispatch (and
+      # any push-triggered caller) on a feature ref. Compared against the
+      # repository's OWN default branch rather than the literal `main`, so an
+      # app still on `master` is guarded, not wedged.
+      - name: Assert the calling ref is the default branch
+        if: github.ref != format('refs/heads/{0}', github.event.repository.default_branch)
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          echo "::error title=Build Candidate::candidates build from the default branch only -- $GITHUB_REF is not refs/heads/$DEFAULT_BRANCH. Merge the change to $DEFAULT_BRANCH, then dispatch."
+          exit 1
+
       - name: Resolve project name & validate type
         id: info
         run: |
@@ -66,6 +82,17 @@ jobs:
     needs: setup
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # One candidate build per project at a time. The no-change guard below is a
+    # read-then-build check, so without a lock a dispatch racing the 05:00 cron
+    # builds the same git sha twice and burns two build numbers.
+    # cancel-in-progress is false deliberately: let the first build finish, and
+    # the second then finds sha-<gitsha> already pushed and reuses its candidate.
+    # Keyed on the project; project-name is optional on this workflow, so it
+    # falls back to the repository (the group is scoped to the CALLING repository
+    # either way, so both forms name one app).
+    concurrency:
+      group: build-candidate-${{ inputs.project-name || github.repository }}
+      cancel-in-progress: false
     # Candidates are prod-bound: they authenticate with the app's PRODUCTION-env
     # github-actions SA (which holds AR writer on the app's shared-registry repo),
     # so the env-scoped vars.GCP_* below are the production environment's values.
@@ -241,6 +268,11 @@ jobs:
     needs: setup
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # One candidate build per project at a time -- see the Cloud Run job's
+    # comment. Only one runtime job ever runs, so they share the group.
+    concurrency:
+      group: build-candidate-${{ inputs.project-name || github.repository }}
+      cancel-in-progress: false
     # Candidates are prod-bound: they build with the app's PRODUCTION-env
     # GitHubRole (arn:aws:iam::056154071827:role/<project>-prod-GitHubRole). The
     # aws/ecs/app v2 module change grants that role ECR push on the app's repo +
@@ -405,6 +437,11 @@ jobs:
     needs: setup
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # One candidate build per project at a time -- see the Cloud Run job's
+    # comment. Only one runtime job ever runs, so they share the group.
+    concurrency:
+      group: build-candidate-${{ inputs.project-name || github.repository }}
+      cancel-in-progress: false
     # Candidates are prod-bound: they build with the app's PRODUCTION-env
     # GitHubRole (arn:aws:iam::056154071827:role/<project>-prod-GitHubRole), which
     # grants ECR push on the app's repo + the build-number DynamoDB counter — the
@@ -575,3 +612,71 @@ jobs:
 
       - name: Notify success
         run: echo "::notice title=Candidate Ready::${{ needs.setup.outputs.project-name }} ${{ steps.existing.outputs.candidate || steps.built.outputs.candidate }}"
+
+  # Build-failure notification. Every other v2 Slack message is posted from the
+  # deploy path, which is reached through `needs: build` -- so it only ever runs
+  # on SUCCESS, and a broken nightly is otherwise completely silent. This job
+  # closes that gap without asking app repos to hold a new secret: SLACK_BOT_TOKEN
+  # stays in cru-deploy, and the GitHubDeployECS role that reads the app's
+  # SlackChannel out of app-info trusts cru-deploy rather than the app repo, so
+  # the app repo can neither look the channel up nor post. What it CAN do is
+  # dispatch, with the org CRU_DEPLOY_GITHUB_TOKEN that `secrets: inherit`
+  # already hands this workflow -- so the notification is a dispatch of
+  # cru-deploy's Notify Build Failure (v2), which does the lookup and posts the
+  # :x: + run-URL message (the same shape as the deploy path's failure notify).
+  #
+  # Telemetry policy: a notification NEVER changes a run's outcome, in either
+  # direction. The dispatch is continue-on-error, and a caller that did not pass
+  # `secrets: inherit` (no token) is a warning, not a failure. An app with no
+  # SlackChannel in app-info is a silent no-op on the cru-deploy side, matching
+  # the rest of the fleet.
+  notify-failure:
+    name: Notify build failure
+    needs: [setup, build-cloudrun, build-ecs, build-lambda]
+    # Exactly one runtime job ever runs; the other two are SKIPPED, not failed,
+    # so the explicit per-job results are the honest test. Deliberately does NOT
+    # fire when `setup` fails: a rejected ref or an unknown `type` is a caller
+    # mistake whose error is already the run's output, and the project name would
+    # be unknown anyway.
+    if: >-
+      ${{ !cancelled()
+      && (needs.build-cloudrun.result == 'failure'
+      || needs.build-ecs.result == 'failure'
+      || needs.build-lambda.result == 'failure') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      # `secrets` is not available in any `if:`, so the token-presence check is a
+      # step of its own rather than a condition on the dispatch.
+      - name: Check for the cru-deploy dispatch token
+        id: token
+        env:
+          DISPATCH_TOKEN: ${{ secrets.CRU_DEPLOY_GITHUB_TOKEN }}
+        run: |
+          if [ -z "$DISPATCH_TOKEN" ]; then
+            echo "::warning title=Build failure not announced::CRU_DEPLOY_GITHUB_TOKEN is unset (the caller does not pass 'secrets: inherit'); skipping the Slack notification."
+            exit 0
+          fi
+          echo "present=true" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout Cru Actions & Workflows
+        if: steps.token.outputs.present == 'true'
+        uses: actions/checkout@v7
+        with:
+          repository: CruGlobal/.github
+          ref: ${{ inputs.workflow-ref }}
+          path: cru-github-actions
+
+      # github.repository and github.run_id are the CALLER's, so the run URL
+      # points at the app repo's failed run -- the reader's next step.
+      - name: Announce the failure via cru-deploy
+        if: steps.token.outputs.present == 'true'
+        continue-on-error: true
+        uses: ./cru-github-actions/actions/dispatch
+        with:
+          github-token: ${{ secrets.CRU_DEPLOY_GITHUB_TOKEN }}
+          workflow: notify-build-failure.yml
+          inputs-json: >-
+            {"project-name": "${{ needs.setup.outputs.project-name }}",
+             "run-url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}

--- a/.github/workflows/notify-build-failure.yml
+++ b/.github/workflows/notify-build-failure.yml
@@ -1,0 +1,95 @@
+name: Notify Build Failure
+
+# Announce a FAILED candidate build in the app's Slack channel.
+#
+# Why this is a separate workflow, and why it runs here rather than in the app
+# repo: build-candidate runs in the app repo, which holds no Slack credential,
+# and the GitHubDeployECS role that reads the app's SlackChannel out of app-info
+# trusts cru-deploy, not the app repo. So build-candidate's failure job only
+# dispatches (with the org CRU_DEPLOY_GITHUB_TOKEN it already inherits), and
+# cru-deploy's thin `Notify Build Failure (v2)` wrapper calls this workflow with
+# its SLACK_BOT_TOKEN. Nothing is checked out here, so there is no workflow-ref
+# input to keep in step with the `uses:` ref.
+#
+# Not a deploy: this workflow reads one DynamoDB item and posts one message. It
+# never fails the thing it reports on -- every failure mode below is a warning.
+
+on:
+  workflow_call:
+    inputs:
+      project-name:
+        type: string
+        required: true
+        description: Project name (app repo name) whose candidate build failed.
+      run-url:
+        type: string
+        required: true
+        description: URL of the failed build run in the app repo.
+    secrets:
+      slack-bot-token:
+        required: false
+        description: Slack bot token for pipeline notifications; unset disables posting.
+
+jobs:
+  notify:
+    name: Notify Slack
+    runs-on: ubuntu-latest
+    # OIDC only: the job assumes GitHubDeployECS to read app-info from DynamoDB
+    # and checks nothing out.
+    permissions:
+      id-token: write
+    steps:
+      - name: Configure AWS credentials for app-info
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::056154071827:role/GitHubDeployECS
+
+      # Same table and column as the deploy path's lookup, read from the
+      # `production` row: a candidate build belongs to no single environment, and
+      # production is the row every onboarded app is guaranteed to have (an app
+      # can still be waiting on its stage environment). A missing row is a
+      # warning, never an error -- see the header.
+      - name: Look up the app's Slack channel
+        id: app-info
+        env:
+          PROJECT_NAME: ${{ inputs.project-name }}
+        run: |
+          info=$(aws dynamodb get-item --region us-east-1 --output json \
+            --table-name CruApplicationInfo \
+            --key "$(jq -n --arg project "$PROJECT_NAME" \
+              '{Project: {S: $project}, Environment: {S: "production"}}')") || true
+          item=$(echo "$info" | jq -c '.Item // empty' 2>/dev/null || true)
+          if [ -z "$item" ]; then
+            echo "::warning title=Build failure not announced::no CruApplicationInfo row for project '$PROJECT_NAME' (production); nowhere to post."
+            exit 0
+          fi
+          echo "slack-channel=$(echo "$item" | jq -r '.SlackChannel.S // empty')" >> "$GITHUB_OUTPUT"
+
+      # The mirror of the deploy path's failure notify: same SlackChannel
+      # destination (channel #name/C… or user U…), same "channel OR token unset
+      # ⇒ silent no-op", same deliberately plain two lines -- a failed build has
+      # nothing new to go look at, so the run URL is the whole second line.
+      - name: Notify Slack
+        continue-on-error: true
+        env:
+          SLACK_CHANNEL: ${{ steps.app-info.outputs.slack-channel }}
+          SLACK_BOT_TOKEN: ${{ secrets.slack-bot-token }}
+          PROJECT_NAME: ${{ inputs.project-name }}
+          RUN_URL: ${{ inputs.run-url }}
+        run: |
+          if [ -z "$SLACK_CHANNEL" ] || [ -z "$SLACK_BOT_TOKEN" ]; then
+            exit 0
+          fi
+          payload=$(jq -n \
+            --arg channel "$SLACK_CHANNEL" \
+            --arg project "$PROJECT_NAME" \
+            --arg runurl "$RUN_URL" \
+            '{channel: $channel,
+              text: (":x: *\($project) candidate build FAILED*"
+                     + "\n\($runurl)")}')
+          response=$(curl -fsS https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+            -H "Content-Type: application/json; charset=utf-8" \
+            -d "$payload") || { echo "::warning title=Slack notify failed::post failed (non-blocking)"; exit 0; }
+          echo "$response" | jq -e '.ok' >/dev/null || { echo "::warning title=Slack notify failed::$(echo "$response" | jq -r '.error // "post failed"') (non-blocking)"; }


### PR DESCRIPTION
Three fleet-level gaps in the v2 build entrypoint, from an external review of the pipeline. All three
land in `build-candidate.yml` — the one file every onboarding reads.

> **This merges onto the live fleet surface.** `pipeline-v2` is not a staging branch: 11 apps pin
> `build-candidate.yml@pipeline-v2` (ararat, terrabloks, tachyon-app, okta-api-keypalive, semaphore,
> bills, clm, hoax, estate-gift-management, cru-app-info, mirage-server), so all three changes are in
> effect for the whole fleet the moment this merges — starting with tonight's 05:00 UTC nightlies.

## 1. Candidates build from the default branch only

A dispatched run checked out whatever ref it was called on and built a **promotable** candidate from
it. Nothing downstream re-checks provenance: `deploy-candidate` deploys the tag it is handed, and
`promote` re-tags it `release-*` for production. A `workflow_dispatch` on a feature branch was one
click from a production-bound artifact built from unreviewed code.

`setup`'s first step now asserts the calling ref:

```yaml
      - name: Assert the calling ref is the default branch
        if: github.ref != format('refs/heads/{0}', github.event.repository.default_branch)
```

- Compared against the repository's **own** `default_branch` from the event payload, not the literal
  `main`, so an app still on `master` is guarded rather than wedged.
- `schedule` needs no coverage: GitHub only ever runs scheduled workflows on the default branch. The
  payload carries `repository` for both `schedule` and `workflow_dispatch`
  ([changelog, 2022-09-27](https://github.blog/changelog/2022-09-27-github-actions-additional-information-available-in-github-event-payload-for-scheduled-workflow-runs/)).
- Message: `candidates build from the default branch only -- <ref> is not refs/heads/<default>`.
- It is in `setup`, so it fails before a build number is burned or an image is pushed.

## 2. A concurrency lock (the last v2 reusable without one)

`promote`, `rollback` and `deploy-candidate` all lock; `build-candidate` did not. The no-change guard
is a **read-then-build** check (`resolve-image` on `sha-<gitsha>`, `continue-on-error`), so a manual
dispatch racing the 05:00 cron read "not built yet" twice and built the same git sha twice — two
build numbers, two pushes of the same bytes, and a race on which `candidate-*` tag the sha ends up
carrying.

```yaml
    concurrency:
      group: build-candidate-${{ inputs.project-name || github.repository }}
      cancel-in-progress: false
```

- On each runtime build job (only one ever runs, so they share the group), matching how
  `deploy-candidate` carries `release-candidate-<project>` on its provider jobs.
- `cancel-in-progress: false` is the point: the first build finishes, and the second then finds
  `sha-<gitsha>` already pushed and **reuses** its candidate — the guard does the deduplication once
  it is no longer racing.
- `project-name` is optional on this workflow, so the group falls back to the repository. Groups are
  scoped to the calling repository either way, so both forms name one app.
- `setup` stays **outside** the lock, so a bad `type` or a non-default ref still fails fast instead of
  queueing behind a 30-minute build.

## 3. A failed build now says so in Slack

Every v2 Slack message is posted from the deploy path, which is reached through `needs: build` — so
it only ever runs on **success**. A broken nightly build was silent: the app repo's Actions tab went
red and nobody was told. (The deploy path's own failure notify exists because two days of failed
weekend nightlies were notified to no one; this is the same lesson one job earlier.)

**No app repo holds a new secret.** `build-candidate` runs in the app repo, which has no
`SLACK_BOT_TOKEN` and cannot assume `GitHubDeployECS` (that role trusts cru-deploy, not app repos), so
it can neither look up the app's `SlackChannel` nor post. What it *can* do is dispatch, with the org
`CRU_DEPLOY_GITHUB_TOKEN` that `secrets: inherit` already hands it. So:

- a final `notify-failure` job dispatches cru-deploy's `Notify Build Failure (v2)` with the project
  name and the app-repo run URL (`github.repository`/`github.run_id` are the caller's in a reusable
  workflow, so the link points at the failed run), via the existing `actions/dispatch`;
- new reusable `notify-build-failure.yml` (called by that wrapper, which holds the token) does the
  ordinary app-info lookup and posts the deploy path's `:x:` + run-URL message verbatim in shape:
  `:x: *<project> candidate build FAILED*` / `<run url>`;
- it reads the **production** app-info row — a candidate build belongs to no environment, and that is
  the row every onboarded app has (an app can still be waiting on its stage environment).

Failure semantics, matching the rest of the fleet: no `SlackChannel` (or no bot token) is a **silent
no-op**; no dispatch token, i.e. a caller without `secrets: inherit`, is a `::warning`; the dispatch
is `continue-on-error`. A notification never changes a run's outcome in either direction. The job
fires only when the runtime job that actually ran **failed** (the other two are *skipped*, not
failed, so the condition names them explicitly) and deliberately not when `setup` fails — a rejected
ref or a bad `type` is a caller mistake whose error is already the run's output, and the project name
would be unknown anyway.

## Merge order with cru-deploy

The receiver is a separate PR: **CruGlobal/cru-deploy#16** (that repo does not allow
auto-merge). Either can land first — until the receiver exists the dispatch 404s, which is a
non-blocking `::warning` by construction, so the only cost of merging this first is that a build
failure in the gap stays as silent as it is today.

No JS changed, so `dist/` needs no rebuild; the notify job reuses the already-built
`actions/dispatch`. `deploy-candidate.yml` is deliberately untouched (another change is in flight
there).

`Lint, Build & Test` fails on `npm ci` (the `@emnapi/*` lockfile drift already on `pipeline-v2` — every
PR off that branch fails the same way, and #440 is the fix). Nothing here touches JS or the lockfile.
