### PR TITLE
ci: build dist on main only

### DIFF
--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -16,11 +16,7 @@ name: Build dist/
 
 on:
   push:
-    # pipeline-v2 is a long-lived v2 branch that carries its own built dist/, so
-    # branch consumers always get freshly built bundles. checkout@v7 checks out
-    # the pushed ref (github.ref) and add-and-commit commits back to that same
-    # branch, so the rebuild lands on whichever branch triggered it.
-    branches: [main, pipeline-v2]
+    branches: [main]
     paths-ignore:
       - 'dist/**'
   workflow_dispatch:


### PR DESCRIPTION
Now that v2.0.0 is released, the v2 development branch is retiring, so the `dist/` rebuild goes back to triggering on `main` alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)